### PR TITLE
feat: implement txid

### DIFF
--- a/src/message/entities/principal.ts
+++ b/src/message/entities/principal.ts
@@ -40,7 +40,10 @@ export class ContractName implements Encodeable {
 
   static decode(source: ResizableByteStream): ContractName {
     const len = source.readUint8();
-    return new ContractName(len, source.readBytesAsHexString(len));
+    return new ContractName(
+      len,
+      source.readBytesAsBuffer(len).toString('ascii')
+    );
   }
 
   encode(target: ResizableByteStream): void {

--- a/src/message/entities/transaction-payload.ts
+++ b/src/message/entities/transaction-payload.ts
@@ -26,16 +26,20 @@ export class TokenTransferPayload extends TransactionPayload {
   readonly recipient_principal: Principal;
   /** An 8-byte number denominating the number of microSTX to send to the recipient address's account. */
   readonly amount: bigint;
+  // 34-byte memo field
+  readonly memo: string;
 
   constructor(
     recipient_type: number,
     recipient_principal: Principal,
-    amount: bigint
+    amount: bigint,
+    memo: string
   ) {
     super();
     this.recipient_type = recipient_type;
     this.recipient_principal = recipient_principal;
     this.amount = amount;
+    this.memo = memo;
   }
 
   static decode(source: ResizableByteStream): TokenTransferPayload {
@@ -49,7 +53,8 @@ export class TokenTransferPayload extends TransactionPayload {
     return new TokenTransferPayload(
       recipient_type,
       principal,
-      source.readUint64()
+      source.readUint64(),
+      source.readBytesAsHexString(34)
     );
   }
 }
@@ -108,7 +113,9 @@ export class ContractCallPayload extends TransactionPayload {
   static decode(source: ResizableByteStream): ContractCallPayload {
     const principal = ContractPrincipal.decode(source);
     const function_name_length = source.readUint8();
-    const function_name = source.readBytesAsHexString(function_name_length);
+    const function_name = source
+      .readBytesAsBuffer(function_name_length)
+      .toString('ascii');
     return new ContractCallPayload(
       principal,
       function_name_length,

--- a/src/peer-handler.ts
+++ b/src/peer-handler.ts
@@ -363,6 +363,7 @@ export class StacksPeer extends EventEmitter {
         // check if message deserialization read the expected length
         if (byteStream.position < payloadLength + Preamble.BYTE_SIZE) {
           logger.error(
+            receivedMsg.payload,
             `Message deserialization error: payload ${
               receivedMsg.payload.constructor.name
             } is expected to be ${payloadLength} bytes, but only ${


### PR DESCRIPTION
* Added a txid property to the Transaction object
* Fixed a few bugs with Transaction and Clarity value decoding that were causing issues with the tx data payload not being correct for the txid hashing
* Made several transaction and clarity value fields human-readable strings