### PR TITLE
feat: register relayer endpoints as possible peers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "env-schema": "5.2.0",
         "fastify": "4.17.0",
         "fastify-metrics": "10.3.0",
+        "ip": "1.1.8",
         "lru-cache": "9.1.1",
         "pino": "8.14.1",
         "public-ip": "6.0.1",
@@ -22,6 +23,7 @@
       },
       "devDependencies": {
         "@types/better-sqlite3": "7.6.4",
+        "@types/ip": "1.1.0",
         "@types/jest": "29.5.1",
         "@types/node": "20.2.1",
         "@types/secp256k1": "4.0.3",
@@ -1445,6 +1447,15 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
       "integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ=="
+    },
+    "node_modules/@types/ip": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ip/-/ip-1.1.0.tgz",
+      "integrity": "sha512-dwNe8gOoF70VdL6WJBwVHtQmAX4RMd62M+mAB9HQFjG1/qiCLM/meRy95Pd14FYBbEDwCq7jgJs89cHpLBu4HQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.4",
@@ -3986,6 +3997,11 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+    },
+    "node_modules/ip": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.8.tgz",
+      "integrity": "sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg=="
     },
     "node_modules/ip-regex": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "env-schema": "5.2.0",
     "fastify": "4.17.0",
     "fastify-metrics": "10.3.0",
+    "ip": "1.1.8",
     "lru-cache": "9.1.1",
     "pino": "8.14.1",
     "public-ip": "6.0.1",
@@ -31,6 +32,7 @@
   },
   "devDependencies": {
     "@types/better-sqlite3": "7.6.4",
+    "@types/ip": "1.1.0",
     "@types/jest": "29.5.1",
     "@types/node": "20.2.1",
     "@types/secp256k1": "4.0.3",


### PR DESCRIPTION
This also starts ignoring private IP addresses for possible outbound peers (since they will never be reachable)